### PR TITLE
Add ContextHandler API function to externally provided net/context.Context

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/schema"
 	"github.com/graphql-go/graphql"
 	"github.com/unrolled/render"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -104,9 +105,9 @@ func getRequestOptions(r *http.Request) *requestOptions {
 	}
 }
 
-// ServeHTTP provides an entry point into executing graphQL queries
-func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
+// ContextHandler provides an entrypoint into executing graphQL queries with a
+// user-provided context.
+func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	// get query
 	opts := getRequestOptions(r)
 
@@ -116,11 +117,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RequestString:  opts.Query,
 		VariableValues: opts.Variables,
 		OperationName:  opts.OperationName,
+		Context:        ctx,
 	}
 	result := graphql.Do(params)
 
 	// render result
 	h.render.JSON(w, http.StatusOK, result)
+}
+
+// ServeHTTP provides an entrypoint into executing graphQL queries.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.ContextHandler(context.Background(), w, r)
 }
 
 type Config struct {


### PR DESCRIPTION
Following https://github.com/graphql-go/graphql/pull/98, it's now possible
to provide a Context to the graphql resolve functions.  This exposes that
capability in the handler API.

This follows the convention of putting the Context as the first arg, and
the apparently evolving context-aware http handler func signature.