### PR TITLE
Include `Authorization` header in `RootObject` handler param

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -112,6 +112,10 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	// get query
 	opts := NewRequestOptions(r)
 
+	// send the authorization header with the root object
+	root := make(map[string]interface{})
+	root["Authorization"] = r.Header.Get("Authorization")
+
 	// execute graphql query
 	params := graphql.Params{
 		Schema:         *h.Schema,
@@ -119,6 +123,7 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 		VariableValues: opts.Variables,
 		OperationName:  opts.OperationName,
 		Context:        ctx,
+		RootObject:     root,
 	}
 	result := graphql.Do(params)
 


### PR DESCRIPTION
I'm using `jwt` in my application and I wanted to include the `Authorization` header in graphql requests so I can return the correct viewer and related data. I don't know, but I don't think this is the best way to accomplish this, and it's certainly not generic. I wanted to start a discussion.

@sogko Do you think it make sense to add this header to the `RootObject` and include it? I wasn't sure, and think it might be more appropriate to include it in the user context `Context` param.

It seems that in either case it would be easy to retrieve the header from the `ResolveParams`:

`p.Info.RootValue.(map[string]interface{})["Authorization"].(string)`