### PR TITLE
Using alternative contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ func main() {
 }
 ```
 
+By default, `context.Background()` is used to generate contexts. If you need to provide an alternative method to support environments, like AppEngine, you can provide a RequestContextGenerator.
+
+```go
+package main
+
+import (
+  "net/http"
+
+  "golang.org/x/net/context"
+  "github.com/graphql-go/handler"
+  "google.golang.org/appengine"
+)
+
+type contextGenerator struct {
+
+}
+
+func (cg *contextGenerator) MakeContext(w http.ResponseWriter, r *http.Request) (context.Context, error) {
+    ctx := appengine.NewContext(r)
+
+    return ctx, nil
+}
+
+func main() {
+
+  // define GraphQL schema using relay library helpers
+  schema := graphql.NewSchema(...)
+  
+  h := handler.New(&handler.Config{
+    Schema: schema,
+    Pretty: true,
+  })
+
+  cg := &contextGenerator{}
+  h.SetRequestContextGenerator(cg)
+
+  // serve HTTP
+  http.Handle("/graphql", h)
+  http.ListenAndServe(":8080", nil)
+}
+```
+
 ### Details
 
 The handler will accept requests with

--- a/handler.go
+++ b/handler.go
@@ -21,8 +21,10 @@ const (
 type Handler struct {
 	Schema *graphql.Schema
 	
+	cg *ContextGenerator
 	pretty bool
 }
+
 type RequestOptions struct {
 	Query         string                 `json:"query" url:"query" schema:"query"`
 	Variables     map[string]interface{} `json:"variables" url:"variables" schema:"variables"`
@@ -140,6 +142,22 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 		buff, _ := json.Marshal(result)
 	
 		w.Write(buff)
+	}
+}
+
+type ContextGenerator interface {
+	MakeContext(w http.ResponseWriter, r *http.Request) (context.Context, error)
+}
+
+func (h *Handler) SetContextGenerator(cg *ContextGenerator) {
+	h.cg = cg
+}
+
+func (h *Handler) GetContext(w http.ResponseWriter, r *http.Request) (ctx context.Context, err error) {
+	if h.cg != nil {
+		return h.cg.MakeContext(w, r)
+	} else {
+		return context.Background(), nil
 	}
 }
 


### PR DESCRIPTION
Currently, you always use context.Background() to generate contexts, but this my not work on particular platforms, like AppEngine. You can now provide a factory to generate these.
