### PR TITLE
Fix “variables” unmarshalling in getFromForm

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -42,7 +42,7 @@ func getFromForm(values url.Values) *RequestOptions {
 		// get variables map
 		var variables map[string]interface{}
 		variablesStr := values.Get("variables")
-		json.Unmarshal([]byte(variablesStr), variables)
+		json.Unmarshal([]byte(variablesStr), &variables)
 
 		return &RequestOptions{
 			Query:         query,


### PR DESCRIPTION
Passing variables by value always results in an empty map.
