### PR TITLE
Updated to use Go 1.7 request based context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 go:
   - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
 
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/handler.go
+++ b/handler.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/graphql-go/graphql"
-
 	"golang.org/x/net/context"
+
+	"github.com/graphql-go/graphql"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 
 type Handler struct {
 	Schema *graphql.Schema
-	
+
 	pretty bool
 }
 type RequestOptions struct {
@@ -129,7 +129,6 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	result := graphql.Do(params)
 
-	
 	if h.pretty {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.MarshalIndent(result, "", "\t")
@@ -138,14 +137,9 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	} else {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.Marshal(result)
-	
+
 		w.Write(buff)
 	}
-}
-
-// ServeHTTP provides an entrypoint into executing graphQL queries.
-func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.ContextHandler(context.Background(), w, r)
 }
 
 type Config struct {

--- a/handler_17_test.go
+++ b/handler_17_test.go
@@ -1,0 +1,62 @@
+// +build go1.7
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
+)
+
+func TestContextPropagatedFromRequest(t *testing.T) {
+	myNameQuery := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"name": &graphql.Field{
+				Name: "name",
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return p.Context.Value("name"), nil
+				},
+			},
+		},
+	})
+
+	myNameSchema, err := graphql.NewSchema(graphql.SchemaConfig{Query: myNameQuery})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"name": "context-data",
+		},
+	}
+	queryString := `query={name}`
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
+
+	h := New(&Config{Schema: &myNameSchema, Pretty: true})
+
+	ctx := context.WithValue(req.Context(), "name", "context-data")
+	*req = *req.WithContext(ctx)
+
+	resp := httptest.NewRecorder()
+
+	h.ServeHTTP(resp, req)
+
+	result := decodeResponse(t, resp)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected server response %v", resp.Code)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+type faction struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+var rebels = &faction{
+	"RmFjdGlvbjox",
+	"Alliance to Restore the Republic",
+}
+
+var factionType = graphql.NewObject(graphql.ObjectConfig{
+	Name:        "Faction",
+	Description: "A faction in the Star Wars saga",
+	Fields: graphql.Fields{
+		"id": &graphql.Field{
+			Type:        graphql.String,
+			Description: "Id of the faction",
+		},
+		"name": &graphql.Field{
+			Type:        graphql.String,
+			Description: "The name of the faction.",
+		},
+	},
+})
+
+var queryType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "Query",
+	Fields: graphql.Fields{
+		"rebels": &graphql.Field{
+			Type: factionType,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				return rebels, nil
+			},
+		},
+	},
+})
+
+var schema, _ = graphql.NewSchema(graphql.SchemaConfig{
+	Query: queryType,
+})

--- a/serve_http.go
+++ b/serve_http.go
@@ -1,0 +1,10 @@
+// +build go1.7
+
+package handler
+
+import "net/http"
+
+// ServeHTTP provides an entrypoint into executing graphQL queries.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.ContextHandler(r.Context(), w, r)
+}

--- a/serve_http_legacy.go
+++ b/serve_http_legacy.go
@@ -1,0 +1,14 @@
+// +build !go1.7
+
+package handler
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// ServeHTTP provides an entrypoint into executing graphQL queries.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.ContextHandler(context.Background(), w, r)
+}


### PR DESCRIPTION
Since context has been merged as stable in Go 1.7 and is now part of the request object (https://godoc.org/net/http#Request)[https://godoc.org/net/http#Request].  This pull request modifies the behavior of the ServeHTTP method to use the request.Context() on go 1.7.  Backward compatibility is preserved for version less than 1.7 by using build constraints.

I have also refactored the tests a little removing the TODO and adding a specific test for Go 1.7 context in the request.