### PR TITLE
Fix unmarshalling `variables` from form data

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -42,7 +42,7 @@ func getFromForm(values url.Values) *RequestOptions {
 		// get variables map
 		var variables map[string]interface{}
 		variablesStr := values.Get("variables")
-		json.Unmarshal([]byte(variablesStr), variables)
+		json.Unmarshal([]byte(variablesStr), &variables)
 
 		return &RequestOptions{
 			Query:         query,

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -150,6 +150,27 @@ func TestRequestOptions_POST_ContentTypeApplicationJSON(t *testing.T) {
 		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestRequestOptions_GET_WithVariablesAsObject(t *testing.T) {
+	query := url.QueryEscape("query RebelsShipsQuery { rebels { name } }")
+	variables := url.QueryEscape(`{ "a": 1, "b": "2" }`)
+	queryString := fmt.Sprintf("query=%s&variables=%s", query, variables)
+	expected := &RequestOptions{
+		Query: "query RebelsShipsQuery { rebels { name } }",
+		Variables: map[string]interface{}{
+			"a": float64(1),
+			"b": "2",
+		},
+	}
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
+	result := NewRequestOptions(req)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
+	}
+}
+
 func TestRequestOptions_POST_ContentTypeApplicationJSON_WithVariablesAsObject(t *testing.T) {
 	body := `
 	{


### PR DESCRIPTION
This fixes a problem that prevented submitting variables via querystring parameters or URL-encoded form parameters