### PR TITLE
Fixed bug with variables of graphql query

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -20,7 +20,7 @@ const (
 
 type Handler struct {
 	Schema *graphql.Schema
-	
+
 	pretty bool
 }
 type RequestOptions struct {
@@ -40,9 +40,9 @@ func getFromForm(values url.Values) *RequestOptions {
 	query := values.Get("query")
 	if query != "" {
 		// get variables map
-		var variables map[string]interface{}
+		variables := make(map[string]interface{})
 		variablesStr := values.Get("variables")
-		json.Unmarshal([]byte(variablesStr), variables)
+		json.Unmarshal([]byte(variablesStr), &variables)
 
 		return &RequestOptions{
 			Query:         query,
@@ -129,7 +129,6 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	result := graphql.Do(params)
 
-	
 	if h.pretty {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.MarshalIndent(result, "", "\t")
@@ -138,7 +137,7 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	} else {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.Marshal(result)
-	
+
 		w.Write(buff)
 	}
 }

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -150,6 +150,27 @@ func TestRequestOptions_POST_ContentTypeApplicationJSON(t *testing.T) {
 		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestRequestOptions_GET_WithVariablesAsObject(t *testing.T) {
+	variables := url.QueryEscape(`{ "a": 1, "b": "2" }`)
+	query := url.QueryEscape("query RebelsShipsQuery { rebels { name } }")
+	queryString := fmt.Sprintf("query=%s&variables=%s", query, variables)
+	expected := &RequestOptions{
+		Query: "query RebelsShipsQuery { rebels { name } }",
+		Variables: map[string]interface{}{
+			"a": float64(1),
+			"b": "2",
+		},
+	}
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
+	result := NewRequestOptions(req)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
+	}
+}
+
 func TestRequestOptions_POST_ContentTypeApplicationJSON_WithVariablesAsObject(t *testing.T) {
 	body := `
 	{


### PR DESCRIPTION
This fixes a problem that prevented submitting variables via querystring parameters or URL-encoded form parameters