### PR TITLE
use context from http request

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -145,7 +145,7 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 
 // ServeHTTP provides an entrypoint into executing graphQL queries.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.ContextHandler(context.Background(), w, r)
+	h.ContextHandler(r.Context(), w, r)
 }
 
 type Config struct {


### PR DESCRIPTION
The idea behind this is that if I use standard http mux with a middleware, for an example, to set currently authenticated user into the request's context it's not working as expected