### PR TITLE
Use http.Request.Context() instead of context.Background()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.7
+  - 1.8
   - tip
 
 before_install:

--- a/handler.go
+++ b/handler.go
@@ -20,7 +20,7 @@ const (
 
 type Handler struct {
 	Schema *graphql.Schema
-	
+
 	pretty bool
 }
 type RequestOptions struct {
@@ -129,7 +129,6 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	result := graphql.Do(params)
 
-	
 	if h.pretty {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.MarshalIndent(result, "", "\t")
@@ -138,14 +137,14 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	} else {
 		w.WriteHeader(http.StatusOK)
 		buff, _ := json.Marshal(result)
-	
+
 		w.Write(buff)
 	}
 }
 
 // ServeHTTP provides an entrypoint into executing graphQL queries.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.ContextHandler(context.Background(), w, r)
+	h.ContextHandler(r.Context(), w, r)
 }
 
 type Config struct {


### PR DESCRIPTION
To better interoperate with middleware frameworks, it makes more sense to pass the http.Request's context instead of a context.Background(). That way user may better control the query with deadline, or inject [dataloader](https://github.com/nicksrandall/dataloader) from outside the Handler.

Also bumped the travis test versions and include go1.8.