### PR TITLE
handler: fixes queryparams variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.swp

--- a/handler.go
+++ b/handler.go
@@ -40,7 +40,7 @@ func getFromForm(values url.Values) *RequestOptions {
 	query := values.Get("query")
 	if query != "" {
 		// get variables map
-		variables := make(map[string]interface{})
+		variables := make(map[string]interface{}, len(values))
 		variablesStr := values.Get("variables")
 		json.Unmarshal([]byte(variablesStr), &variables)
 

--- a/handler.go
+++ b/handler.go
@@ -20,7 +20,6 @@ const (
 
 type Handler struct {
 	Schema *graphql.Schema
-
 	pretty   bool
 	graphiql bool
 }
@@ -41,9 +40,9 @@ func getFromForm(values url.Values) *RequestOptions {
 	query := values.Get("query")
 	if query != "" {
 		// get variables map
-		var variables map[string]interface{}
+		variables := make(map[string]interface{})
 		variablesStr := values.Get("variables")
-		json.Unmarshal([]byte(variablesStr), variables)
+		json.Unmarshal([]byte(variablesStr), &variables)
 
 		return &RequestOptions{
 			Query:         query,

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -150,6 +150,27 @@ func TestRequestOptions_POST_ContentTypeApplicationJSON(t *testing.T) {
 		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestRequestOptions_GET_WithVariablesAsObject(t *testing.T) {
+	variables := url.QueryEscape(`{ "a": 1, "b": "2" }`)
+	query := url.QueryEscape("query RebelsShipsQuery { rebels { name } }")
+	queryString := fmt.Sprintf("query=%s&variables=%s", query, variables)
+	expected := &RequestOptions{
+		Query: "query RebelsShipsQuery { rebels { name } }",
+		Variables: map[string]interface{}{
+			"a": float64(1),
+			"b": "2",
+		},
+	}
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
+	result := NewRequestOptions(req)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
+	}
+}
+
 func TestRequestOptions_POST_ContentTypeApplicationJSON_WithVariablesAsObject(t *testing.T) {
 	body := `
 	{

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -14,7 +14,8 @@ import (
 func TestRequestOptions_GET_BasicQueryString(t *testing.T) {
 	queryString := "query=query RebelsShipsQuery { rebels { name } }"
 	expected := &RequestOptions{
-		Query: "query RebelsShipsQuery { rebels { name } }",
+		Query:     "query RebelsShipsQuery { rebels { name } }",
+		Variables: make(map[string]interface{}),
 	}
 
 	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
@@ -69,7 +70,8 @@ func TestRequestOptions_GET_ContentTypeApplicationUrlEncoded(t *testing.T) {
 func TestRequestOptions_POST_BasicQueryString_WithNoBody(t *testing.T) {
 	queryString := "query=query RebelsShipsQuery { rebels { name } }"
 	expected := &RequestOptions{
-		Query: "query RebelsShipsQuery { rebels { name } }",
+		Query:     "query RebelsShipsQuery { rebels { name } }",
+		Variables: make(map[string]interface{}),
 	}
 
 	req, _ := http.NewRequest("POST", fmt.Sprintf("/graphql?%v", queryString), nil)
@@ -244,7 +246,8 @@ func TestRequestOptions_POST_ContentTypeApplicationUrlEncoded(t *testing.T) {
 	data.Add("query", "query RebelsShipsQuery { rebels { name } }")
 
 	expected := &RequestOptions{
-		Query: "query RebelsShipsQuery { rebels { name } }",
+		Query:     "query RebelsShipsQuery { rebels { name } }",
+		Variables: make(map[string]interface{}),
 	}
 
 	req, _ := http.NewRequest("POST", "/graphql", bytes.NewBufferString(data.Encode()))
@@ -284,7 +287,8 @@ func TestRequestOptions_POST_ContentTypeApplicationUrlEncoded_WithNilBody(t *tes
 func TestRequestOptions_PUT_BasicQueryString(t *testing.T) {
 	queryString := "query=query RebelsShipsQuery { rebels { name } }"
 	expected := &RequestOptions{
-		Query: "query RebelsShipsQuery { rebels { name } }",
+		Query:     "query RebelsShipsQuery { rebels { name } }",
+		Variables: make(map[string]interface{}),
 	}
 
 	req, _ := http.NewRequest("PUT", fmt.Sprintf("/graphql?%v", queryString), nil)
@@ -339,7 +343,8 @@ func TestRequestOptions_PUT_ContentTypeApplicationUrlEncoded(t *testing.T) {
 func TestRequestOptions_DELETE_BasicQueryString(t *testing.T) {
 	queryString := "query=query RebelsShipsQuery { rebels { name } }"
 	expected := &RequestOptions{
-		Query: "query RebelsShipsQuery { rebels { name } }",
+		Query:     "query RebelsShipsQuery { rebels { name } }",
+		Variables: make(map[string]interface{}),
 	}
 
 	req, _ := http.NewRequest("DELETE", fmt.Sprintf("/graphql?%v", queryString), nil)


### PR DESCRIPTION
#### Overview
- handler: fixes to use pointer instead to unmarshal correctly.
- request_options_test: adds test for sending query params.
- based various previous PR's: #10, #13, #15, #16, #18 — thanks a lot for your contribution :+1: 

#### Test plan
- Unit test.