### PR TITLE
handler: replaces Handler.Schema with Handler.Params (graphql.Params)

### DIFF
--- a/graphcoolPlayground_test.go
+++ b/graphcoolPlayground_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/handler"
 )
@@ -62,7 +63,9 @@ func TestRenderPlayground(t *testing.T) {
 			req.Header.Set("Accept", tc.accept)
 
 			h := handler.New(&handler.Config{
-				Schema:     &testutil.StarWarsSchema,
+				Params: graphql.Params{
+					Schema: testutil.StarWarsSchema,
+				},
 				GraphiQL:   false,
 				Playground: tc.playgroundEnabled,
 			})

--- a/graphiql_test.go
+++ b/graphiql_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
 	"github.com/graphql-go/handler"
 )
@@ -62,7 +63,9 @@ func TestRenderGraphiQL(t *testing.T) {
 			req.Header.Set("Accept", tc.accept)
 
 			h := handler.New(&handler.Config{
-				Schema:   &testutil.StarWarsSchema,
+				Params: graphql.Params{
+					Schema: testutil.StarWarsSchema,
+				},
 				GraphiQL: tc.graphiqlEnabled,
 			})
 

--- a/handler.go
+++ b/handler.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/graphql-go/graphql"
-
-	"context"
 )
 
 const (
@@ -19,8 +17,7 @@ const (
 )
 
 type Handler struct {
-	Schema *graphql.Schema
-	RootObject map[string]interface{}
+	Params   graphql.Params
 	pretty   bool
 	graphiql bool
 	playground bool
@@ -115,28 +112,18 @@ func NewRequestOptions(r *http.Request) *RequestOptions {
 	}
 }
 
-// ContextHandler provides an entrypoint into executing graphQL queries with a
-// user-provided context.
-func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	// get query
+// ServeHTTP provides an entrypoint into executing graphQL queries.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	opts := NewRequestOptions(r)
-
-	// execute graphql query
-	params := graphql.Params{
-		Schema:         *h.Schema,
-		RequestString:  opts.Query,
-		VariableValues: opts.Variables,
-		OperationName:  opts.OperationName,
-		RootObject:     h.RootObject,
-		Context:        ctx,
-	}
-	result := graphql.Do(params)
-
+	h.Params.RequestString = opts.Query
+	h.Params.VariableValues = opts.Variables
+	h.Params.OperationName = opts.OperationName
+	result := graphql.Do(h.Params)
 	if h.graphiql {
 		acceptHeader := r.Header.Get("Accept")
 		_, raw := r.URL.Query()["raw"]
 		if !raw && !strings.Contains(acceptHeader, "application/json") && strings.Contains(acceptHeader, "text/html") {
-			renderGraphiQL(w, params)
+			renderGraphiQL(w, h.Params)
 			return
 		}
 	}
@@ -166,42 +153,18 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 }
 
-// ServeHTTP provides an entrypoint into executing graphQL queries.
-func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.ContextHandler(r.Context(), w, r)
-}
-
 type Config struct {
-	Schema   *graphql.Schema
-	RootObject map[string]interface{}
+	Params   graphql.Params
 	Pretty   bool
 	GraphiQL bool
 	Playground bool
 }
 
-func NewConfig() *Config {
-	return &Config{
-		Schema:   nil,
-		RootObject: map[string]interface{}{},
-		Pretty:   true,
-		GraphiQL: true,
-		Playground: false,
-	}
-}
-
-func New(p *Config) *Handler {
-	if p == nil {
-		p = NewConfig()
-	}
-	if p.Schema == nil {
-		panic("undefined GraphQL schema")
-	}
-
+func New(c *Config) *Handler {
 	return &Handler{
-		Schema:   p.Schema,
-		RootObject: p.RootObject,
-		pretty:   p.Pretty,
-		graphiql: p.GraphiQL,
-		playground: p.Playground,
+		Params:   c.Params,
+		pretty:   c.Pretty,
+		graphiql: c.GraphiQL,
+		playground: c.Playground,
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -19,9 +19,10 @@ const (
 )
 
 type Handler struct {
-	Schema     *graphql.Schema
-	pretty     bool
-	graphiql   bool
+	Schema *graphql.Schema
+	RootObject map[string]interface{}
+	pretty   bool
+	graphiql bool
 	playground bool
 }
 type RequestOptions struct {
@@ -126,6 +127,7 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 		RequestString:  opts.Query,
 		VariableValues: opts.Variables,
 		OperationName:  opts.OperationName,
+		RootObject:     h.RootObject,
 		Context:        ctx,
 	}
 	result := graphql.Do(params)
@@ -170,17 +172,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type Config struct {
-	Schema     *graphql.Schema
-	Pretty     bool
-	GraphiQL   bool
+	Schema   *graphql.Schema
+	RootObject map[string]interface{}
+	Pretty   bool
+	GraphiQL bool
 	Playground bool
 }
 
 func NewConfig() *Config {
 	return &Config{
-		Schema:     nil,
-		Pretty:     true,
-		GraphiQL:   true,
+		Schema:   nil,
+		RootObject: map[string]interface{}{},
+		Pretty:   true,
+		GraphiQL: true,
 		Playground: false,
 	}
 }
@@ -194,9 +198,10 @@ func New(p *Config) *Handler {
 	}
 
 	return &Handler{
-		Schema:     p.Schema,
-		pretty:     p.Pretty,
-		graphiql:   p.GraphiQL,
+		Schema:   p.Schema,
+		RootObject: p.RootObject,
+		pretty:   p.Pretty,
+		graphiql: p.GraphiQL,
 		playground: p.Playground,
 	}
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -168,7 +168,9 @@ func TestHandler_Params_RootObject(t *testing.T) {
 			},
 		},
 	})
-	myNameSchema, err := graphql.NewSchema(graphql.SchemaConfig{myNameQuery, nil})
+	myNameSchema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: myNameQuery,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Overview

- handler: replaces `*Handler.Schema` with `Handler.Params` ([graphql.Params](https://github.com/graphql-go/graphql/blob/master/graphql.go#L11)).
  - So we can actually send to `graphql.Do(...)` the params we exactly need, like Context, RootObject, etc.
- handler_test:
  - TestHandler_Params_NilParams: removes it since we want to `graphql.Do` handle validation errors such us schema is nil.
  - TestHandler_Params_RootObject: adds test unit to check we are passing correctly `graphql.Params.RootObject` — thanks a lot @nossila :+1: 
- graphiql_test: updates it to use `handler.Config.Params`.
- Closes: #1

#### Action required
- Add the following within `Breaking Changes` section when shipping a new release including this PR:
***
- `Handler.Schema` was replaced by `Handler.Params` [graphql.Params](https://github.com/graphql-go/graphql/blob/master/graphql.go#L11):
- Before:
```go
h := handler.New(&handler.Config{
  Schema: testutil.StarWarsSchema,
  GraphiQL: true,
})
```
- Now:
```go
h := handler.New(&handler.Config{
  Params: graphql.Params{
    Schema: testutil.StarWarsSchema,
  },
  GraphiQL: true,
})
```
***

#### Test plan
- Unit test:
- Manual test, via GraphiQL:
![image](https://user-images.githubusercontent.com/1000404/31590363-5847a190-b1d4-11e7-9121-7ab90f1acb76.png)

```go
package main

import (
        "net/http"
        "github.com/graphql-go/handler"
        "github.com/graphql-go/graphql"
        "github.com/graphql-go/graphql/testutil"
)

func main() {
        h := handler.New(&handler.Config{
                // Before:
                // Schema: &testutil.StarWarsSchema,

                // Now:
                Params: graphql.Params{
                        Schema: testutil.StarWarsSchema,
                },

                Pretty: true,
                GraphiQL: true,
        })
        http.Handle("/graphql", h)
        http.ListenAndServe(":8080", nil)
}
```