### PR TITLE
User json encoder

### DIFF
--- a/graphiql_test.go
+++ b/graphiql_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package handler
 
 import (
 	"net/http"
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/graphql-go/graphql/testutil"
-	"github.com/graphql-go/handler"
 )
 
 func TestRenderGraphiQL(t *testing.T) {
@@ -61,7 +60,7 @@ func TestRenderGraphiQL(t *testing.T) {
 
 			req.Header.Set("Accept", tc.accept)
 
-			h := handler.New(&handler.Config{
+			h := New(&Config{
 				Schema:   &testutil.StarWarsSchema,
 				GraphiQL: tc.graphiqlEnabled,
 			})

--- a/handler.go
+++ b/handler.go
@@ -140,18 +140,14 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	// use proper JSON Header
 	w.Header().Add("Content-Type", "application/json; charset=utf-8")
-
+	w.WriteHeader(http.StatusOK)
+	
+	enc := json.NewEncoder(w)
 	if h.pretty {
-		w.WriteHeader(http.StatusOK)
-		buff, _ := json.MarshalIndent(result, "", "\t")
-
-		w.Write(buff)
-	} else {
-		w.WriteHeader(http.StatusOK)
-		buff, _ := json.Marshal(result)
-
-		w.Write(buff)
+		enc.SetIndent("", "\t")
 	}
+	// Not much you can do with this error.
+	_ = enc.Encode(result)
 }
 
 // ServeHTTP provides an entrypoint into executing graphQL queries.

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package handler
 
 import (
 	"encoding/json"
@@ -13,7 +13,6 @@ import (
 	"context"
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
-	"github.com/graphql-go/handler"
 )
 
 func decodeResponse(t *testing.T, recorder *httptest.ResponseRecorder) *graphql.Result {
@@ -32,7 +31,8 @@ func decodeResponse(t *testing.T, recorder *httptest.ResponseRecorder) *graphql.
 	}
 	return &target
 }
-func executeTest(t *testing.T, h *handler.Handler, req *http.Request) (*graphql.Result, *httptest.ResponseRecorder) {
+
+func executeTest(t *testing.T, h *Handler, req *http.Request) (*graphql.Result, *httptest.ResponseRecorder) {
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 	result := decodeResponse(t, resp)
@@ -67,7 +67,7 @@ func TestContextPropagated(t *testing.T) {
 	queryString := `query={name}`
 	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
 
-	h := handler.New(&handler.Config{
+	h := New(&Config{
 		Schema: &myNameSchema,
 		Pretty: true,
 	})
@@ -95,7 +95,7 @@ func TestHandler_BasicQuery_Pretty(t *testing.T) {
 	queryString := `query=query HeroNameQuery { hero { name } }`
 	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
 
-	h := handler.New(&handler.Config{
+	h := New(&Config{
 		Schema: &testutil.StarWarsSchema,
 		Pretty: true,
 	})
@@ -119,7 +119,7 @@ func TestHandler_BasicQuery_Ugly(t *testing.T) {
 	queryString := `query=query HeroNameQuery { hero { name } }`
 	req, _ := http.NewRequest("GET", fmt.Sprintf("/graphql?%v", queryString), nil)
 
-	h := handler.New(&handler.Config{
+	h := New(&Config{
 		Schema: &testutil.StarWarsSchema,
 		Pretty: false,
 	})
@@ -147,6 +147,6 @@ func TestHandler_Params_NilParams(t *testing.T) {
 		}
 		t.Fatalf("expected to panic, did not panic")
 	}()
-	_ = handler.New(nil)
+	_ = New(nil)
 
 }


### PR DESCRIPTION
Making the JSON serialization more efficient by writing to the stream directly instead of creating an intermediate buffer and then writing that.

Cleaning up the tests.  The package was being imported explicitly which means tests will not test changes in forked repositories.  Made the test package name the same as the package to make sure tests are testing the code in the current repo.