### PR TITLE
Added Support for CustomErrorFormatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 *.swp
+.idea


### PR DESCRIPTION
This is an add-on for https://github.com/graphql-go/graphql/pull/379 (it requires that to be merged to compile)
 
It basically adds a feature to be able to set a custom error formatter in case you have custom error objects returning in queries / mutation fields.

Example:

```go
func CustomFormat(err error) gqlerrors.FormattedError {
	switch err := err.(type) {
	case *gqlerrors.Error:
		cf := CustomFormat(err.OriginalError)
		cf.Locations = err.Locations
		cf.Path = err.Path
		return cf
	case gqlerrors.ExtendedError:
		return gqlerrors.FormatError(err)
	case *QuantoError.ErrorObject:
		return err.ToFormattedError()
	default:
		return gqlerrors.FormatError(err)
	}
}

func GetGraphQLHandler(config graphql.SchemaConfig) *handler.Handler {
	schema, err := graphql.NewSchema(config)

	if err != nil {
		logger.Errorf("failed to create new schema, error: %v", err)
		return nil
	}

	h := handler.New(&handler.Config{
		Schema:   &schema,
		Pretty:   true,
		GraphiQL: true,
		CustomErrorFormatter: CustomFormat,
	})

	return h
}
```