### PR TITLE
README: Updates build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# graphql-go-handler [![Build Status](https://travis-ci.org/graphql-go/handler.svg)](https://travis-ci.org/graphql-go/handler) [![GoDoc](https://godoc.org/graphql-go/handler?status.svg)](https://godoc.org/github.com/graphql-go/handler) [![Coverage Status](https://coveralls.io/repos/graphql-go/handler/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-go/handler?branch=master) [![Join the chat at https://gitter.im/graphql-go/graphql](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/graphql-go/graphql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# graphql-go-handler [![CircleCI](https://circleci.com/gh/graphql-go/handler.svg?style=svg)](https://circleci.com/gh/graphql-go/handler) [![GoDoc](https://godoc.org/graphql-go/handler?status.svg)](https://godoc.org/github.com/graphql-go/handler) [![Coverage Status](https://coveralls.io/repos/graphql-go/handler/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-go/handler?branch=master) [![Join the chat at https://gitter.im/graphql-go/graphql](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/graphql-go/graphql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 
 Golang HTTP.Handler for [graphl-go](https://github.com/graphql-go/graphql)
 


### PR DESCRIPTION
#### Overview
- Follow-up PR from: https://github.com/graphql-go/handler/pull/48 
- ci: Replaces TravisCI build badge with CircleCI badge

#### Test plan

![1](https://user-images.githubusercontent.com/1000404/45918561-4fdc7100-be78-11e8-99cb-4447ecae9272.png)
