### PR TITLE
handler: adds formatErrorFn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 *.swp
+.idea

--- a/handler.go
+++ b/handler.go
@@ -133,12 +133,19 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 		VariableValues:      opts.Variables,
 		OperationName:       opts.OperationName,
 		Context:             ctx,
-		CustomErrorFomatter: h.customErrorFormatter,
 	}
 	if h.rootObjectFn != nil {
 		params.RootObject = h.rootObjectFn(ctx, r)
 	}
 	result := graphql.Do(params)
+
+	if customFormatter := h.customErrorFormatter; customFormatter != nil {
+		formatted := make([]gqlerrors.FormattedError, len(result.Errors))
+		for i, err := range result.Errors {
+			formatted[i] = customFormatter(err.OriginalError())
+		}
+		result.Errors = formatted
+	}
 
 	if h.graphiql {
 		acceptHeader := r.Header.Get("Accept")

--- a/handler.go
+++ b/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/graphql-go/graphql"
 
 	"context"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 )
 
@@ -28,7 +29,7 @@ type Handler struct {
 	playground       bool
 	rootObjectFn     RootObjectFn
 	resultCallbackFn ResultCallbackFn
-	formatErrorFn    func(err error) gqlerrors.FormattedError
+	formatErrorFn    func(err gqlerrors.FormattedError) gqlerrors.FormattedError
 }
 
 type RequestOptions struct {
@@ -140,10 +141,10 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	result := graphql.Do(params)
 
-	if formatErrorFn := h.formatErrorFn; formatErrorFn != nil {
+	if formatErrorFn := h.formatErrorFn; formatErrorFn != nil && len(result.Errors) > 0 {
 		formatted := make([]gqlerrors.FormattedError, len(result.Errors))
-		for i, err := range result.Errors {
-			formatted[i] = formatErrorFn(err.OriginalError())
+		for i, formattedError := range result.Errors {
+			formatted[i] = formatErrorFn(formattedError)
 		}
 		result.Errors = formatted
 	}
@@ -202,7 +203,7 @@ type Config struct {
 	Playground       bool
 	RootObjectFn     RootObjectFn
 	ResultCallbackFn ResultCallbackFn
-	FormatErrorFn    func(err error) gqlerrors.FormattedError
+	FormatErrorFn    func(err gqlerrors.FormattedError) gqlerrors.FormattedError
 }
 
 func NewConfig() *Config {


### PR DESCRIPTION
#### Overview
- Built on top of: https://github.com/graphql-go/handler/pull/46 — thanks a lot @racerxdl :+1: 
- Now that `graphql-go/graphql` added support for [`FormattedError.OriginalError()`](https://github.com/graphql-go/graphql/pull/423) this PR adds support for adding a custom error formatter via `Handler.formatErrorFn` which matches the reference implementation:

  ```javascript
  graphqlHTTP({
    schema: GraphQLSchema,
    graphiql?: ?boolean,
    rootValue?: ?any,
    context?: ?any,
    pretty?: ?boolean,
    formatError?: ?Function, <----------------
    validationRules?: ?Array<any>,
  }): Middleware
  ```
  Ref: [Link](https://graphql.org/graphql-js/express-graphql/#graphqlhttp)


#### Test plan
- Unit tests
- Adds `Handler.formatErrorFn` tests