### PR TITLE
Fixed the endpoint embedded in the playground's html template

### DIFF
--- a/graphcoolPlayground.go
+++ b/graphcoolPlayground.go
@@ -24,7 +24,7 @@ func renderPlayground(w http.ResponseWriter, r *http.Request) {
 
 	d := playgroundData{
 		PlaygroundVersion:    graphcoolPlaygroundVersion,
-		Endpoint:             "/graphql",
+		Endpoint:             r.URL.Path,
 		SubscriptionEndpoint: fmt.Sprintf("ws://%v/subscriptions", r.Host),
 		SetTitle:             true,
 	}


### PR DESCRIPTION
I would like to use an endpoint other than `/graphql` for playground. Therefore, i modified to use path of requested url.
![image](https://user-images.githubusercontent.com/9394354/49867244-3a5e5e00-fe4d-11e8-8589-a2e544cefad0.png)

