### PR TITLE
Add Config support for specifying a PlaygroundEndpoint

### DIFF
--- a/graphcoolPlayground.go
+++ b/graphcoolPlayground.go
@@ -14,7 +14,7 @@ type playgroundData struct {
 }
 
 // renderPlayground renders the Playground GUI
-func renderPlayground(w http.ResponseWriter, r *http.Request) {
+func renderPlayground(w http.ResponseWriter, r *http.Request, endpoint string) {
 	t := template.New("Playground")
 	t, err := t.Parse(graphcoolPlaygroundTemplate)
 	if err != nil {
@@ -24,7 +24,7 @@ func renderPlayground(w http.ResponseWriter, r *http.Request) {
 
 	d := playgroundData{
 		PlaygroundVersion:    graphcoolPlaygroundVersion,
-		Endpoint:             r.URL.Path,
+		Endpoint:             endpoint,
 		SubscriptionEndpoint: fmt.Sprintf("ws://%v/subscriptions", r.Host),
 		SetTitle:             true,
 	}

--- a/handler.go
+++ b/handler.go
@@ -23,13 +23,14 @@ const (
 type ResultCallbackFn func(ctx context.Context, params *graphql.Params, result *graphql.Result, responseBody []byte)
 
 type Handler struct {
-	Schema           *graphql.Schema
-	pretty           bool
-	graphiql         bool
-	playground       bool
-	rootObjectFn     RootObjectFn
-	resultCallbackFn ResultCallbackFn
-	formatErrorFn    func(err error) gqlerrors.FormattedError
+	Schema             *graphql.Schema
+	pretty             bool
+	graphiql           bool
+	playground         bool
+	playgroundEndpoint string
+	rootObjectFn       RootObjectFn
+	resultCallbackFn   ResultCallbackFn
+	formatErrorFn      func(err error) gqlerrors.FormattedError
 }
 
 type RequestOptions struct {
@@ -162,7 +163,11 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 		acceptHeader := r.Header.Get("Accept")
 		_, raw := r.URL.Query()["raw"]
 		if !raw && !strings.Contains(acceptHeader, "application/json") && strings.Contains(acceptHeader, "text/html") {
-			renderPlayground(w, r)
+			endpoint := h.playgroundEndpoint
+			if endpoint == "" {
+				endpoint = r.URL.Path
+			}
+			renderPlayground(w, r, endpoint)
 			return
 		}
 	}
@@ -197,13 +202,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type RootObjectFn func(ctx context.Context, r *http.Request) map[string]interface{}
 
 type Config struct {
-	Schema           *graphql.Schema
-	Pretty           bool
-	GraphiQL         bool
-	Playground       bool
-	RootObjectFn     RootObjectFn
-	ResultCallbackFn ResultCallbackFn
-	FormatErrorFn    func(err error) gqlerrors.FormattedError
+	Schema             *graphql.Schema
+	Pretty             bool
+	GraphiQL           bool
+	Playground         bool
+	PlaygroundEndpoint string
+	RootObjectFn       RootObjectFn
+	ResultCallbackFn   ResultCallbackFn
+	FormatErrorFn      func(err error) gqlerrors.FormattedError
 }
 
 func NewConfig() *Config {
@@ -225,12 +231,13 @@ func New(p *Config) *Handler {
 	}
 
 	return &Handler{
-		Schema:           p.Schema,
-		pretty:           p.Pretty,
-		graphiql:         p.GraphiQL,
-		playground:       p.Playground,
-		rootObjectFn:     p.RootObjectFn,
-		resultCallbackFn: p.ResultCallbackFn,
-		formatErrorFn:    p.FormatErrorFn,
+		Schema:             p.Schema,
+		pretty:             p.Pretty,
+		graphiql:           p.GraphiQL,
+		playground:         p.Playground,
+		playgroundEndpoint: p.PlaygroundEndpoint,
+		rootObjectFn:       p.RootObjectFn,
+		resultCallbackFn:   p.ResultCallbackFn,
+		formatErrorFn:      p.FormatErrorFn,
 	}
 }


### PR DESCRIPTION
In some deployments e.g. serverless the default endpoint being set does not work. Have added a PlaygroundEndpoint field to the Config to allow this to be explicitly specified (if this is not provided the default will still be used)