### PR TITLE
handler: adds go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/graphql-go/handler
+
+go 1.14


### PR DESCRIPTION
#### Overview
- Adds `go.mod` file, using the minimum required version that supports go mod: `go1.14`.

- The absence of `go.mod` makes the build fail for: `golang:latest` version, found via PR: https://github.com/graphql-go/handler/pull/78

<img width="694" alt="build" src="https://user-images.githubusercontent.com/1000404/110209637-153be700-7ec0-11eb-9a2d-5cddb839fb89.png">

^ Ref: https://circleci.com/gh/graphql-go/handler/105

***


#### Test plan
- Tested via `golang:latest` [go1.16](https://hub.docker.com/layers/circleci/golang/latest/images/sha256-718de429223b9abb6ea4fe03b95867345ce5b1dcb293dd400b5e50c41e5d875f?context=explore) build:

<img width="955" alt="ok" src="https://user-images.githubusercontent.com/1000404/110209472-61d2f280-7ebf-11eb-8d62-c3aab763d90a.png">

^ Ref: https://app.circleci.com/pipelines/github/graphql-go/handler/20/workflows/5bdd6b09-956d-4f22-b88f-35b87f31176c/jobs/110