### PR TITLE
Add ability to configure GraphcoolPlayground endpoint + subscription endpoint

### DIFF
--- a/graphcoolPlayground.go
+++ b/graphcoolPlayground.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"html/template"
 	"net/http"
 )
@@ -14,7 +13,7 @@ type playgroundData struct {
 }
 
 // renderPlayground renders the Playground GUI
-func renderPlayground(w http.ResponseWriter, r *http.Request) {
+func renderPlayground(w http.ResponseWriter, r *http.Request, endpoint string, subscriptionEndpoint string) {
 	t := template.New("Playground")
 	t, err := t.Parse(graphcoolPlaygroundTemplate)
 	if err != nil {
@@ -24,16 +23,14 @@ func renderPlayground(w http.ResponseWriter, r *http.Request) {
 
 	d := playgroundData{
 		PlaygroundVersion:    graphcoolPlaygroundVersion,
-		Endpoint:             r.URL.Path,
-		SubscriptionEndpoint: fmt.Sprintf("ws://%v/subscriptions", r.Host),
+		Endpoint:             endpoint,
+		SubscriptionEndpoint: subscriptionEndpoint,
 		SetTitle:             true,
 	}
 	err = t.ExecuteTemplate(w, "index", d)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-
-	return
 }
 
 const graphcoolPlaygroundVersion = "1.5.2"


### PR DESCRIPTION
Hello! I've been using graphql-go successfully in my app for a while now, but I've had to use a standalone GraphQL client for testing because the handler package's bundled GraphiQL doesn't support HTTP headers, and the bundled Playground don't allow me to change the websocket endpoint.

Right now the endpoint and websocket endpoint are hardcoded in this package to be relative to the request's url, but this doesn't work in cases where the websocket is served off of a different subdomain. Also the "ws" protocol is hardcoded but in production environments, most people are using "wss".

This proposed change allows users to optionally pass an additional PlaygroundConfig object in the main Handler Config which can change the endpoint and subscription endpoint. If it's not included, but the Playground flag is true, the original behavior is retained so as not to break existing users.

If you have a better idea of how to accomplish this, I'm all ears! I'd just love to be able to do all of my testing from a web browser without needing some Electron app as well.