### PR TITLE
Adds support for setting GraphQL Playground endpoints.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/graphql-go/handler
 
 go 1.14
+
+require github.com/graphql-go/graphql v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=

--- a/graphcoolPlayground.go
+++ b/graphcoolPlayground.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"html/template"
 	"net/http"
 )
@@ -14,7 +13,7 @@ type playgroundData struct {
 }
 
 // renderPlayground renders the Playground GUI
-func renderPlayground(w http.ResponseWriter, r *http.Request) {
+func renderPlayground(w http.ResponseWriter, r *http.Request, endpoint string, subscriptionEndpoint string) {
 	t := template.New("Playground")
 	t, err := t.Parse(graphcoolPlaygroundTemplate)
 	if err != nil {
@@ -24,16 +23,14 @@ func renderPlayground(w http.ResponseWriter, r *http.Request) {
 
 	d := playgroundData{
 		PlaygroundVersion:    graphcoolPlaygroundVersion,
-		Endpoint:             r.URL.Path,
-		SubscriptionEndpoint: fmt.Sprintf("ws://%v/subscriptions", r.Host),
+		Endpoint:             endpoint,
+		SubscriptionEndpoint: subscriptionEndpoint,
 		SetTitle:             true,
 	}
 	err = t.ExecuteTemplate(w, "index", d)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-
-	return
 }
 
 const graphcoolPlaygroundVersion = "1.5.2"

--- a/handler_test.go
+++ b/handler_test.go
@@ -290,3 +290,61 @@ func TestHandler_BasicQuery_WithFormatErrorFn(t *testing.T) {
 		t.Fatalf("wrong result, graphql result diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestPlayground(t *testing.T) {
+	query := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"ping": &graphql.Field{
+				Name: "ping",
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "OK", nil
+				},
+			},
+		},
+	})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: query,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", "/custom-path/graphql", nil)
+	req.Header.Set("Accept", "text/html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := handler.New(&handler.Config{
+		Schema:     &schema,
+		Playground: true,
+		PlaygroundConfig: &handler.PlaygroundConfig{
+			Endpoint:             "/custom-path/graphql",
+			SubscriptionEndpoint: "/custom-path/ws",
+		},
+	})
+
+	resp := httptest.NewRecorder()
+	h.ContextHandler(context.Background(), resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected server response %v", resp.Code)
+	}
+
+	expectedBodyContains := []string{
+		`endpoint: "/custom-path/graphql"`,
+		`subscriptionEndpoint: "/custom-path/ws"`,
+	}
+	respBody := resp.Body.String()
+	t.Log(respBody)
+
+	for _, e := range expectedBodyContains {
+		if !strings.Contains(respBody, e) {
+			t.Fatalf("wrong body, expected %s to contain %s", respBody, e)
+		}
+	}
+
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -291,7 +291,60 @@ func TestHandler_BasicQuery_WithFormatErrorFn(t *testing.T) {
 	}
 }
 
-func TestPlayground(t *testing.T) {
+func TestPlaygroundWithDefaultConfig(t *testing.T) {
+	query := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"ping": &graphql.Field{
+				Name: "ping",
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "OK", nil
+				},
+			},
+		},
+	})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: query,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", "/graphql", nil)
+	req.Header.Set("Accept", "text/html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := handler.New(&handler.Config{
+		Schema:     &schema,
+		Playground: true,
+	})
+
+	resp := httptest.NewRecorder()
+	h.ContextHandler(context.Background(), resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected server response %v", resp.Code)
+	}
+
+	expectedBodyContains := []string{
+		"GraphQL Playground",
+		`endpoint: "/graphql"`,
+		`subscriptionEndpoint: "ws:///subscriptions"`,
+	}
+	respBody := resp.Body.String()
+
+	for _, e := range expectedBodyContains {
+		if !strings.Contains(respBody, e) {
+			t.Fatalf("wrong body, expected %s to contain %s", respBody, e)
+		}
+	}
+}
+
+func TestPlaygroundWithCustomConfig(t *testing.T) {
 	query := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
@@ -335,16 +388,15 @@ func TestPlayground(t *testing.T) {
 	}
 
 	expectedBodyContains := []string{
+		"GraphQL Playground",
 		`endpoint: "/custom-path/graphql"`,
 		`subscriptionEndpoint: "/custom-path/ws"`,
 	}
 	respBody := resp.Body.String()
-	t.Log(respBody)
 
 	for _, e := range expectedBodyContains {
 		if !strings.Contains(respBody, e) {
 			t.Fatalf("wrong body, expected %s to contain %s", respBody, e)
 		}
 	}
-
 }


### PR DESCRIPTION
#### Description
- Built on top of: https://github.com/graphql-go/handler/pull/86 — Thanks a lot @AttilaTheFun :+1: 
- `{graphql,graphcoolPlayground.go}`: Adds support for setting GraphQL Playground endpoints, eg:
```go
h := handler.New(&handler.Config{
	Schema:     &schema,
	Playground: true,
	PlaygroundConfig: &handler.PlaygroundConfig{
		Endpoint:             "/custom-path/graphql",
		SubscriptionEndpoint: "/custom-path/ws",
	},
})
```

#### Test Plan
- Unit tests.