### PR TITLE
Update GraphiQL version to 3.8.3 to support Request Headers 

### DIFF
--- a/graphiql.go
+++ b/graphiql.go
@@ -66,7 +66,7 @@ func renderGraphiQL(w http.ResponseWriter, params graphql.Params) {
 }
 
 // graphiqlVersion is the current version of GraphiQL
-const graphiqlVersion = "0.11.11"
+const graphiqlVersion = "3.8.3"
 
 // tmpl is the page template to render GraphiQL
 const graphiqlTemplate = `
@@ -100,8 +100,8 @@ add "&raw" to the end of the URL within a browser.
   <link href="//cdn.jsdelivr.net/npm/graphiql@{{ .GraphiqlVersion }}/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react@18.3.1/umd/react.production.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/graphiql@{{ .GraphiqlVersion }}/graphiql.min.js"></script>
 </head>
 <body>
@@ -143,12 +143,13 @@ add "&raw" to the end of the URL within a browser.
     var fetchURL = locationQuery(otherParams);
 
     // Defines a GraphQL fetcher using the fetch API.
-    function graphQLFetcher(graphQLParams) {
+    function graphQLFetcher(graphQLParams, opts = {headers: {}}) {
       return fetch(fetchURL, {
         method: 'post',
         headers: {
           'Accept': 'application/json',
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...opts.headers
         },
         body: JSON.stringify(graphQLParams),
         credentials: 'include',


### PR DESCRIPTION
GraphiQL version that is used by github.com/graphql-go/handler is 6 years old and it is time to update it.
Also, more modern version of GraphiQL supports two important things:
1. Tabs
2. Request headers.

P.S. There is similar PR but it uses older version - https://github.com/graphql-go/handler/pull/88

Solves issue https://github.com/graphql-go/handler/issues/71